### PR TITLE
Changes to help parse primitive types from Env variables

### DIFF
--- a/examples/simple-array.js
+++ b/examples/simple-array.js
@@ -7,7 +7,10 @@ var config = require('../index').load('envlift-app', {
         user: 'root',
         password: ''
     },
-    hostnames: []  // Reference array that should be overridden by env-variables.
+    hostnames: [ // Reference array that should be overridden by env-variables.
+        {host: 'somehost', port: '8080'},
+        {host: 'someotherhost', port: '8080'}
+    ]
 });
 
 // export the config for testability

--- a/examples/simple-array.js
+++ b/examples/simple-array.js
@@ -1,0 +1,14 @@
+// load config from environment with default provided as an object
+var config = require('../index').load('envlift-app', {
+    port: 80,
+    environment: 'development',
+    db: {
+        host: 'localhost',
+        user: 'root',
+        password: ''
+    },
+    hostnames: []  // Reference array that should be overridden by env-variables.
+});
+
+// export the config for testability
+module.exports = config;

--- a/lib/main.js
+++ b/lib/main.js
@@ -24,7 +24,7 @@ var E = '',
      * Stores the set of typecast functions to be applied when retrieving values from environment.
      *
      * @enum
-     * @type {Objeck<function>}
+     * @type {Object<function>}
      */
     typecasts = {
         'string': String,
@@ -42,6 +42,10 @@ var E = '',
             if (value === TRUE) {
                 return true;
             }
+        },
+        'array': function (value) {
+            return value.replace(/^\s+|\s+$/g,"").  // Remove beginning and trailing spaces
+                         split(/\s*,\s*/);          // Split at <anyspace>,<anyspace>
         }
     },
 
@@ -71,7 +75,11 @@ lift = function (obj, namespace, separator, transformer, _debug) {
         }
 
         // determine the type of the value and extract the casting function.
-        cast = typecasts[typeof obj[key]];
+        var keyType = typeof obj[key];
+        if (keyType === 'object' && Array.isArray(obj[key])) {
+            keyType = 'array';
+        }
+        cast = typecasts[keyType];
         !cast && (obj[key] === null) && (cast = typecasts.undefined); // specially handle null
 
         // generate the equivalent environment key for the namespace

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,10 +45,6 @@ var E = '',
             if (value === TRUE) {
                 return true;
             }
-        },
-        'array': function (value) {
-            return value.replace(/^\s+|\s+$/g, '').  // Remove beginning and trailing spaces
-                         split(/\s*,\s*/);          // Split at <anyspace>,<anyspace>
         }
     },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -75,10 +75,6 @@ lift = function (obj, namespace, separator, transformer, _debug) {
     else if (typeof obj === OBJECT) {
         allKeys = Object.keys(obj);
     }
-    else {
-        // Base case, where the object is a primitive
-        return obj;
-    }
 
     allKeys.forEach(function (key) {
         // only process keys that are owned by this object
@@ -98,9 +94,11 @@ lift = function (obj, namespace, separator, transformer, _debug) {
             cast ? ('[' + cast(process.env[eKey]) + ']') : E);
 
         // if a cast function is there, it implies that native value is detected and we need to lookup environment
-        if (cast && (process.env[eKey] !== undefined)) {
-            // if environment has a defined variable, we replace the original value with this.
-            obj[key] = cast(process.env[eKey]);
+        if (cast) {
+            if (process.env[eKey] !== undefined) {
+                // if environment has a defined variable, we replace the original value with this.
+                obj[key] = cast(process.env[eKey]);
+            }
         }
         // otherwise, we recurse into the value of the property
         else {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,9 @@
 var E = '',
     TRUE = 'true',
     FALSE = 'false',
+    NUMBER = 'number',
+    OBJECT = 'object',
+
     /**
      * Default separator while retrieving values of multi-level keys.
      * @const
@@ -17,10 +20,7 @@ var E = '',
      * @returns {string}
      */
     rekey = function (key, separator) {
-        if (typeof key === 'number') {
-            return key;
-        }
-        return key.toUpperCase().replace(/[^A-Z0-9]/g, separator || E);
+        return (typeof key === NUMBER) ? key : (key.toUpperCase().replace(/[^A-Z0-9]/g, separator || E));
     },
 
     /**
@@ -48,7 +48,7 @@ var E = '',
         }
     },
 
-    // main function that parses objects
+// main function that parses objects
     lift;
 
 /**
@@ -62,11 +62,9 @@ var E = '',
  * transformer function is used to lookup environment variables.
  */
 lift = function (obj, namespace, separator, transformer, _debug) {
-    var key,
-        cast,
+    var cast,
         eKey,
-        allKeys,
-        keyCount;
+        allKeys;
 
     // iterate on each item in this object and operate on their keys.
     if (Array.isArray(obj)) {
@@ -74,7 +72,7 @@ lift = function (obj, namespace, separator, transformer, _debug) {
             length: obj.length
         }).map(Number.call, Number);
     }
-    else if (typeof obj === 'object') {
+    else if (typeof obj === OBJECT) {
         allKeys = Object.keys(obj);
     }
     else {
@@ -82,12 +80,10 @@ lift = function (obj, namespace, separator, transformer, _debug) {
         return obj;
     }
 
-    for (keyCount = 0; keyCount < allKeys.length; keyCount++) {
-        key = allKeys[keyCount];  // key could be an array index or an object property
-
+    allKeys.forEach(function (key) {
         // only process keys that are owned by this object
         if (!obj.hasOwnProperty(key)) {
-            continue;
+            return;
         }
 
         // determine the type of the value and extract the casting function.
@@ -99,7 +95,7 @@ lift = function (obj, namespace, separator, transformer, _debug) {
 
         // debug log
         _debug && (process.env[eKey] !== undefined) && console.log('env-lift: %s=%s', eKey, process.env[eKey],
-            cast ? ('[' + cast(process.env[eKey]) + ']') : E) ;
+            cast ? ('[' + cast(process.env[eKey]) + ']') : E);
 
         // if a cast function is there, it implies that native value is detected and we need to lookup environment
         if (cast && (process.env[eKey] !== undefined)) {
@@ -110,7 +106,7 @@ lift = function (obj, namespace, separator, transformer, _debug) {
         else {
             lift(obj[key], eKey, separator, transformer, _debug);
         }
-    }
+    });
 
     return obj;
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -75,6 +75,9 @@ lift = function (obj, namespace, separator, transformer, _debug) {
     else if (typeof obj === OBJECT) {
         allKeys = Object.keys(obj);
     }
+    else {
+        allKeys = [];  // If this happens, the loop will be skipped completely
+    }
 
     allKeys.forEach(function (key) {
         // only process keys that are owned by this object
@@ -105,7 +108,7 @@ lift = function (obj, namespace, separator, transformer, _debug) {
             lift(obj[key], eKey, separator, transformer, _debug);
         }
     });
-
+    // This is ultimately the configuration, so it has to be returned.
     return obj;
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,6 +17,9 @@ var E = '',
      * @returns {string}
      */
     rekey = function (key, separator) {
+        if (typeof key === 'number') {
+            return key;
+        }
         return key.toUpperCase().replace(/[^A-Z0-9]/g, separator || E);
     },
 
@@ -66,21 +69,33 @@ lift = function (obj, namespace, separator, transformer, _debug) {
     var key,
         cast,
         eKey,
-        keyType;
+        allKeys,
+        keyCount;
 
     // iterate on each item in this object and operate on their keys.
-    for (key in obj) {
+    if (Array.isArray(obj)) {
+        allKeys = Array.apply(null, {
+            length: obj.length
+        }).map(Number.call, Number);
+    }
+    else if (typeof obj === 'object') {
+        allKeys = Object.keys(obj);
+    }
+    else {
+        // Base case, where the object is a primitive
+        return obj;
+    }
+
+    for (keyCount = 0; keyCount < allKeys.length; keyCount++) {
+        key = allKeys[keyCount];  // key could be an array index or an object property
+
         // only process keys that are owned by this object
         if (!obj.hasOwnProperty(key)) {
             continue;
         }
 
         // determine the type of the value and extract the casting function.
-        keyType = typeof obj[key];
-        if (keyType === 'object' && Array.isArray(obj[key])) {
-            keyType = 'array';
-        }
-        cast = typecasts[keyType];
+        cast = typecasts[typeof obj[key]];
         !cast && (obj[key] === null) && (cast = typecasts.undefined); // specially handle null
 
         // generate the equivalent environment key for the namespace
@@ -91,11 +106,9 @@ lift = function (obj, namespace, separator, transformer, _debug) {
             cast ? ('[' + cast(process.env[eKey]) + ']') : E) ;
 
         // if a cast function is there, it implies that native value is detected and we need to lookup environment
-        if (cast) {
+        if (cast && (process.env[eKey] !== undefined)) {
             // if environment has a defined variable, we replace the original value with this.
-            if (process.env[eKey] !== undefined) {
-                obj[key] = cast(process.env[eKey]);
-            }
+            obj[key] = cast(process.env[eKey]);
         }
         // otherwise, we recurse into the value of the property
         else {

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,7 +44,7 @@ var E = '',
             }
         },
         'array': function (value) {
-            return value.replace(/^\s+|\s+$/g,"").  // Remove beginning and trailing spaces
+            return value.replace(/^\s+|\s+$/g, '').  // Remove beginning and trailing spaces
                          split(/\s*,\s*/);          // Split at <anyspace>,<anyspace>
         }
     },
@@ -65,7 +65,8 @@ var E = '',
 lift = function (obj, namespace, separator, transformer, _debug) {
     var key,
         cast,
-        eKey;
+        eKey,
+        keyType;
 
     // iterate on each item in this object and operate on their keys.
     for (key in obj) {
@@ -75,7 +76,7 @@ lift = function (obj, namespace, separator, transformer, _debug) {
         }
 
         // determine the type of the value and extract the casting function.
-        var keyType = typeof obj[key];
+        keyType = typeof obj[key];
         if (keyType === 'object' && Array.isArray(obj[key])) {
             keyType = 'array';
         }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "Postman Labs <help@getpostman.com>",
   "license": "Apache 2.0",
   "bugs": {
-    "url": "https://github.com/postmanlabs/sails-mysql-transactions/issues"
+    "url": "https://github.com/postmanlabs/env-lift/issues"
   },
-  "homepage": "https://github.com/postmanlabs/sails-mysql-transactions",
+  "homepage": "https://github.com/postmanlabs/env-lift",
   "dependencies": { },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/tests/unit/examples-spec.js
+++ b/tests/unit/examples-spec.js
@@ -7,6 +7,7 @@ process.env.ENVLIFT_APP_PORT = '8081';
 process.env.ENVLIFT_APP_ENVIRONMENT = 'production';
 process.env.ENVLIFT_APP_DB_USER = 'toor';
 process.env.ENVLIFT_APP_PM2 = 'false';
+process.env.ENVLIFT_APP_HOSTNAMES = 'localhost,127.0.0.1';
 
 /* global describe, it */
 describe('examples', function () {
@@ -21,5 +22,9 @@ describe('examples', function () {
     it('external-json', function () {
         expect(require('../../examples/external-json.js').db.user).to.be('toor');
         expect(require('../../examples/external-json.js').pm2).to.be(false);
+    });
+
+    it('simple-array', function () {
+        expect(require('../../examples/simple-array.js').hostnames).to.eql(['localhost', '127.0.0.1']);
     });
 });

--- a/tests/unit/examples-spec.js
+++ b/tests/unit/examples-spec.js
@@ -7,7 +7,10 @@ process.env.ENVLIFT_APP_PORT = '8081';
 process.env.ENVLIFT_APP_ENVIRONMENT = 'production';
 process.env.ENVLIFT_APP_DB_USER = 'toor';
 process.env.ENVLIFT_APP_PM2 = 'false';
-process.env.ENVLIFT_APP_HOSTNAMES = 'localhost,127.0.0.1';
+process.env.ENVLIFT_APP_HOSTNAMES_0_HOST = 'localhost';
+process.env.ENVLIFT_APP_HOSTNAMES_0_PORT = '9191';
+process.env.ENVLIFT_APP_HOSTNAMES_1_HOST = 'newhost';
+process.env.ENVLIFT_APP_HOSTNAMES_1_PORT = '2222';
 
 /* global describe, it */
 describe('examples', function () {
@@ -25,6 +28,12 @@ describe('examples', function () {
     });
 
     it('simple-array', function () {
-        expect(require('../../examples/simple-array.js').hostnames).to.eql(['localhost', '127.0.0.1']);
+        expect(require('../../examples/simple-array.js').hostnames).to.eql([{
+            host: 'localhost',
+            port: 9191
+        }, {
+            host: 'newhost',
+            port: 2222
+        }]);
     });
 });


### PR DESCRIPTION
This PR fixes #4 and contains initial work towards #3. 

These changes only support parsing of primitive types. The complex use case discussed in #3 (where an array is composed of multiple objects itself) is not handled yet.
