### PR TITLE
simplifies filling an array + adds minimum node version required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '0.10'
+  - '4.0.0'
 
 deploy:
   provider: npm

--- a/lib/main.js
+++ b/lib/main.js
@@ -68,9 +68,7 @@ lift = function (obj, namespace, separator, transformer, _debug) {
 
     // iterate on each item in this object and operate on their keys.
     if (Array.isArray(obj)) {
-        allKeys = Array.apply(null, {
-            length: obj.length
-        }).map(Number.call, Number);
+        allKeys = Array(obj.length).fill().map(Number.call, Number);
     }
     else if (typeof obj === OBJECT) {
         allKeys = Object.keys(obj);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "env-lift",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "version": "0.0.3",
   "description": "Simple namespaced environment variable configuration management solution",
   "main": "index.js",


### PR DESCRIPTION
- Simplifies the filling of Array with numbers (0..n)
This is more readable as well as [faster](https://jsperf.com/js-range-like) than the previous way
![image](https://user-images.githubusercontent.com/5207331/26923485-d8318d7e-4c5f-11e7-93cf-93ca4d4691f0.png)
- adds a minimum node version required in the package.json
- updates the travis.yml to run on 4.0.0 node version (there is an open PR from zookeeper to change it to version 6, not sure whether we should upgrade to 6 now or not)
